### PR TITLE
Bugfixes for TYPO3 12.4 compatibility

### DIFF
--- a/Classes/Command/MapCacheCommandController.php
+++ b/Classes/Command/MapCacheCommandController.php
@@ -94,7 +94,7 @@ class MapCacheCommandController extends Command
      * @throws \Exception
      * @throws \TYPO3\CMS\Extbase\Object\Exception
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $contentUids = $input->getArgument('contentUids');
         $baseUrl  = $input->getArgument('baseUrl');

--- a/Classes/Command/MapCacheCommandController.php
+++ b/Classes/Command/MapCacheCommandController.php
@@ -21,16 +21,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
 class MapCacheCommandController extends Command
 {
-    /**
-     * @var ObjectManager
-     */
-    protected $objectManager;
-
     /**
      * Configure the command by defining the name, options and arguments
      */
@@ -92,7 +86,6 @@ class MapCacheCommandController extends Command
      * @param OutputInterface $output
      * @return int
      * @throws \Exception
-     * @throws \TYPO3\CMS\Extbase\Object\Exception
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
@@ -107,7 +100,6 @@ class MapCacheCommandController extends Command
         $io = new SymfonyStyle($input, $output);
         $io->title('Start map cache warmup');
 
-        $this->objectManager = GeneralUtility::makeInstance(ObjectManager::class);
         $persistenceManager = GeneralUtility::makeInstance(PersistenceManager::class);
 
         if (trim($contentUids)) {
@@ -152,7 +144,7 @@ class MapCacheCommandController extends Command
             }
 
             if ($className) {
-                $controller = $this->objectManager->get($className);
+                $controller = GeneralUtility::makeInstance($className);
                 $flexformSettings = $this->getFlexFormData($content);
                 $flexformSettings['settings']['backendContext'] = 1;
                 $controller->setSettings($flexformSettings['settings']);

--- a/Classes/Command/NapiSyncCommandController.php
+++ b/Classes/Command/NapiSyncCommandController.php
@@ -66,7 +66,7 @@ class NapiSyncCommandController extends Command
      * @return int
      * @throws ApiException
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $pid = $input->getArgument('pid');
 

--- a/Classes/Command/NapiSyncCommandController.php
+++ b/Classes/Command/NapiSyncCommandController.php
@@ -26,12 +26,11 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 class NapiSyncCommandController extends Command
 {
     /**
-     * @var \TYPO3\CMS\Extbase\Domain\Repository\CategoryRepository
+     * @var \Nordkirche\NkcBase\Domain\Repository\CategoryRepository
      */
     protected $categoryRepository;
 
@@ -39,11 +38,6 @@ class NapiSyncCommandController extends Command
      * @var Api
      */
     protected $api;
-
-    /**
-     * @var ObjectManager
-     */
-    protected $objectManager;
 
     /**
      * Configure the command by defining the name, options and arguments
@@ -73,7 +67,7 @@ class NapiSyncCommandController extends Command
         $io = new SymfonyStyle($input, $output);
         $io->title('Start napi sync');
 
-        $this->categoryRepository = GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\Domain\Repository\CategoryRepository::class);
+        $this->categoryRepository = GeneralUtility::makeInstance(\Nordkirche\NkcBase\Domain\Repository\CategoryRepository::class);
 
         $this->api = ApiService::get();
         $repository = $this->api->factory(CategoryRepository::class);

--- a/Classes/Controller/BaseController.php
+++ b/Classes/Controller/BaseController.php
@@ -303,13 +303,11 @@ class BaseController extends ActionController
     /**
      * @return array
      * @throws InvalidConfigurationTypeException
-     * @throws \TYPO3\CMS\Extbase\Object\Exception
      */
     protected function getTypoScriptConfiguration()
     {
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        $configurationManager = $objectManager->get(ConfigurationManager::class);
-        $typoScriptService = $objectManager->get(TypoScriptService::class);
+        $configurationManager = GeneralUtility::makeInstance(ConfigurationManager::class);
+        $typoScriptService = GeneralUtility::makeInstance(TypoScriptService::class);
         return $typoScriptService->convertTypoScriptArrayToPlainArray($configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT));
     }
 

--- a/Classes/Domain/Model/Category.php
+++ b/Classes/Domain/Model/Category.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nordkirche\NkcBase\Domain\Model;
+
+class Category extends \TYPO3\CMS\Extbase\Domain\Model\Category
+{
+}

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    Nordkirche\NkcBase\Domain\Model\Category::class => [
+        'tableName' => 'sys_category',
+    ],
+];


### PR DESCRIPTION
- Removed `ObjectManager`usages
- Added return type for commands
- Added missing category model and mapping